### PR TITLE
Bump golang from 1.15.10 to 1.16.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG DOCKER_GEN_VERSION=0.7.6
 ARG FOREGO_VERSION=0.16.1
 
 # Use a specific version of golang to build both binaries
-FROM golang:1.15.10 as gobuilder
+FROM golang:1.16.3 as gobuilder
 
 # Build docker-gen from scratch
 FROM gobuilder as dockergen

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -3,7 +3,7 @@ ARG DOCKER_GEN_VERSION=0.7.6
 ARG FOREGO_VERSION=0.16.1
 
 # Use a specific version of golang to build both binaries
-FROM golang:1.15.10-alpine as gobuilder
+FROM golang:1.16.3-alpine as gobuilder
 RUN apk add --no-cache git
 
 # Build docker-gen from scratch


### PR DESCRIPTION
Bumps golang from 1.15.10 to 1.16.3.

Signed-off-by: dependabot[bot] <support@github.com>